### PR TITLE
Extend adapter schema with more options and docs

### DIFF
--- a/adapter-config-schema/README.md
+++ b/adapter-config-schema/README.md
@@ -1,15 +1,16 @@
 # Adapter Config Schema
 
-This folder includes a JSON schema for adapter configurations `adapter_schema.json` together with a settings file for the [MetaConfigurator](https://github.com/MetaConfigurator) `meta_configurator_settings.json`.
+This folder includes the preCICE Adapter and Tooling Configuration Schema (preATCS) `preatcs.json` together with a settings file for the [MetaConfigurator](https://github.com/MetaConfigurator) `meta_configurator_settings.json`.
 
 A schema ...
 
-- defines how a configuration file looks like.
-- enables interoperability.
+- defines how a configuration file looks like (thus replaces any explicit documentation).
+- enables interoperability (through standardization).
 - simplifies auto-generation.
 - enables tooling support (e.g. IDEs or GUIs).
+- enables automatic LLM-based conversion from and to other configuration languages.
 - ...
 
-Such tooling support is, for example, provided by the MetaConfigurator. You can open it with the following link:
+Tooling support is, for example, provided by the MetaConfigurator. You can open it with the following link:
 
-https://metaconfigurator.github.io/meta-configurator/?schema=https://github.com/precice/preeco-orga/blob/main/adapter-config-schema/adapter_schema.json&settings=https://github.com/precice/preeco-orga/blob/main/adapter-config-schema/meta_configurator_settings.json
+https://metaconfigurator.github.io/meta-configurator/?schema=https://github.com/precice/preeco-orga/blob/main/adapter-config-schema/preatcs.json&settings=https://github.com/precice/preeco-orga/blob/main/adapter-config-schema/meta_configurator_settings.json

--- a/adapter-config-schema/preatcs.json
+++ b/adapter-config-schema/preatcs.json
@@ -1,6 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "title": "preCICE Adapter and Tooling Configuration Schema (preATCS)",
+  "description": "A JSON schema for configurations of adapters and tools within the preCICE ecosystem. Use the schema for validation and LLM-based auto-conversion to other configuration languages (e.g., OpenFOAM dictionary or YAML). The schema is developed as part of the preECO standardization, see https://precice.discourse.group/t/shape-the-future-of-the-precice-ecosystem-the-preeco-project/2019.",
   "properties": {
     "participant_name": {
       "type": "string",
@@ -48,14 +50,15 @@
             },
             "minItems": 1
           },
-          "location" : {
+          "location": {
             "type": "string",
             "description": "Further specification of mesh locations",
             "minLength": 1,
             "examples": [
               "faceCenters",
               "volumeCenters",
-              "faceNodes"
+              "faceNodes",
+              "nodes"
             ]
           },
           "write_data_names": {
@@ -70,7 +73,9 @@
                 "Temperature",
                 "Heat-Flux",
                 "Force1",
-                "Force-Left"
+                "Force-Left",
+                "Heat-Transfer-Coefficient",
+                "Sink-Temperature"
               ],
               "minLength": 1,
               "pattern": "^[A-Z][a-zA-Z0-9]*(?:-[A-Za-z0-9]+)*$"
@@ -95,10 +100,32 @@
               "pattern": "^[A-Z][a-zA-Z0-9]*(?:-[A-Za-z0-9]+)*$"
             },
             "minItems": 1
+          },
+          "is_received": {
+            "type": "boolean",
+            "description": "Whether mesh is received from another participant for (direct) API access or not (i.e. provided)."
           }
         },
         "required": [
           "mesh_name"
+        ],
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "is_received": {
+                  "const": true
+                }
+              }
+            },
+            "then": {
+              "not": {
+                "required": [
+                  "location"
+                ]
+              }
+            }
+          }
         ]
       },
       "minItems": 1
@@ -108,6 +135,5 @@
     "participant_name",
     "config_file_name",
     "interfaces"
-  ],
-  "title": "preCICE Adapter Schema"
+  ]
 }

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -71,7 +71,7 @@ We consider an adapter fulfilling all of these criteria as conforming to the pre
 - [ ] R.7: There is an issue tracker.
 - [ ] R.8: There is a code formatting specification (e.g., clang-format specification file).
 - [ ] R.9: The adapter has comments and error messages for at least its main building blocks and entry points. These comments are in English.
-- [ ] R.10: The configuration follows a formally defined schema, which [will be available in the future](https://github.com/precice/preeco-orga/issues/18).
+- [ ] R.10: The configuration follows the [preCICE Adapter and Tooling Configuration Schema](https://github.com/precice/preeco-orga/blob/main/adapter-config-schema/preatcs.json), either directly in JSON or indirectly via LLM-based auto-conversion. Using the standard name `precice-adapter-config.json` is possible (if JSON).
 - [ ] R.11: Any vertices defined through `setMeshVertex` or `setMeshVertices` need to be real locations in space and the data written to the mesh needs to be data located there, i.e., it is not allowed to decode any other information.
 
 ### Additional

--- a/guidelines/guidelines-application-cases.md
+++ b/guidelines/guidelines-application-cases.md
@@ -94,16 +94,18 @@ We consider an application case fulfilling all of these criteria as conforming t
     ```bash
     - <some-application-case>/        # or <some_experiment>
       - README.md                     # see R.3
-      - precice.config.xml            # preCICE configuration file, see R.4-R.7
+      - precice-config.xml            # preCICE configuration file, see R.4-R.7
       - run-all.sh                    # run the complete case, multiple times if necessary (optional)
       - clean.sh                      # clean the complete case (mandatory, see R.8)
       - <solver1>/
         - run.sh                      # run the solver (mandatory, see R.9)
         - clean.sh                    # individual clean script (optional)
+        - precice-adapter-config.json # adapter configuration (if necessary)
         - <the-solver1-files>
       - <solver2>/
         - run.sh
         - clean.sh
+        - precice-adapter-config.json
         - <the-solver2-files>
       - ...
       - <some-other-files>


### PR DESCRIPTION
I will write up a potential blog post on the schema next. There, I want to comment on all of our existing adapters and tools.

@MakisH Mabye it makes sense to wait with your review for a draft of this blog post. Then, the changes here and the current state could be easier to understand.

@Logende Does the `all-of` construction in the schema make sense? Or could this be done in a simpler way?