### PR TITLE
Add export formats

### DIFF
--- a/adapter-config-schema/export-formats/issm-example.yaml
+++ b/adapter-config-schema/export-formats/issm-example.yaml
@@ -1,0 +1,18 @@
+issm-precice:
+  precice:
+    config-file: precice-config.xml
+    participant: ISSM
+  issm:
+    root-path: circle
+    model-name: circle
+  data:
+    mesh:
+      name: ISSM-Mesh
+      type: 2d-horizontal
+      layer: 0
+    recv:
+      - issm-name: Pressure
+        precice-name: Pressure
+    send:
+      - issm-name: Thickness
+        precice-name: IceThickness

--- a/adapter-config-schema/preatcs.json
+++ b/adapter-config-schema/preatcs.json
@@ -1,6 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "metaConfigurator": {
+    "aiExportFormats": {
+      "OpenFOAM": "https://github.com/precice/tutorials/blob/develop/perpendicular-flap/fluid-openfoam/system/preciceDict",
+      "FMI": "https://github.com/precice/tutorials/blob/develop/oscillator/mass-left-fmi/precice-settings.json"
+    }
+  },
   "title": "preCICE Adapter and Tooling Configuration Schema (preATCS)",
   "description": "A JSON schema for configurations of adapters and tools within the preCICE ecosystem. Use the schema for validation and LLM-based auto-conversion to other configuration languages (e.g., OpenFOAM dictionary or YAML). The schema is developed as part of the preECO standardization, see https://precice.discourse.group/t/shape-the-future-of-the-precice-ecosystem-the-preeco-project/2019.",
   "properties": {

--- a/adapter-config-schema/preatcs.json
+++ b/adapter-config-schema/preatcs.json
@@ -4,7 +4,7 @@
   "metaConfigurator": {
     "aiExportFormats": {
       "OpenFOAM": "https://github.com/precice/tutorials/blob/develop/perpendicular-flap/fluid-openfoam/system/preciceDict",
-      "FMI": "https://github.com/precice/tutorials/blob/develop/oscillator/mass-left-fmi/precice-settings.json"
+      "ISSM": "https://github.com/precice/preeco-orga/blob/main/adapter-config-schema/export-formats/issm-example.yaml"
     }
   },
   "title": "preCICE Adapter and Tooling Configuration Schema (preATCS)",


### PR DESCRIPTION
By adding export formats for the AI export to the schema, MetaConfigurator will show these format options to the user, instead of giving the user a prompt where they specify their own export formats. The export format "specification" can be an extensive and comprehensive example file of the given format, or also a textual description and specification.