### PR TITLE
Move the OpenFOAM adapter guidelines example to a separate page

### DIFF
--- a/guidelines/guidelines-adapters-openfoam.md
+++ b/guidelines/guidelines-adapters-openfoam.md
@@ -1,0 +1,46 @@
+---
+title: Standardization example - OpenFOAM adapter
+permalink: community-guidelines-adapters-openfoam.html
+keywords: contribute, develop, adapters, standardization, preECO, OpenFOAM
+summary: A review of the OpenFOAM adapter using the contributing guidelines. This is a work-in-progress that will eventually be moved.
+toc: true
+---
+
+The OpenFOAM adapter conforms to the preCICE best practices and fulfills many of the additional criteria.
+
+Metadata:
+
+- M.1: OpenFOAM
+- M.2: https://precice.org/adapter-openfoam-overview.html
+- M.3: GPL-3.0
+- M.4: Gerasimos Chourdakis `<gerasimos.chourdakis ipvs.uni-stuttgart.de>`, David Schneider `<david.schneider ipvs.uni-stuttgart.de>`
+- M.5: https://doi.org/10.51560/ofj.v3.88
+- M.6: library
+
+Required best practices:
+
+- [x] R.1: Several application cases are available as tutorials. The application cases list is not yet available.
+- [x] R.2: https://github.com/precice/openfoam-adapter/blob/develop/README.md
+- [x] R.3: https://github.com/precice/openfoam-adapter/blob/develop/LICENSE
+- [x] R.4: https://github.com/precice/openfoam-adapter (public)
+- [x] R.5: https://precice.org/adapter-openfoam-get.html#what-does-the-adapter-version-mean
+- [x] R.6: https://github.com/precice/openfoam-adapter/blob/develop/CHANGELOG.md
+- [x] R.7: https://github.com/precice/openfoam-adapter/issues
+- [x] R.8: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
+- [x] R.9: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
+- [ ] R.10: (schema not available yet)
+- [x] R.11: See call to `setMeshVertices` in https://github.com/precice/openfoam-adapter/blob/develop/Interface.C
+
+Additional criteria:
+
+- [x] A.1: GPL-3.0
+- [x] A.2: https://github.com/precice/openfoam-adapter
+- [x] A.3: on precice.org
+- [x] A.4: yes, but only at compile-time
+- [x] A.5: https://doi.org/10.51560/ofj.v3.88
+- [x] A.6: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
+- [x] A.7: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
+- [x] A.8: https://precice.org/adapter-openfoam-extend.html
+- [ ] A.9: There are no unit tests
+- [x] A.10: Already integrated into the system tests
+- [x] A.11: https://packages.spack.io/package.html?name=of-precice

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -45,7 +45,7 @@ The criteria follow at large the [FAIR criteria for research software](https://d
 
 We consider an adapter fulfilling all of these criteria as conforming to the preCICE standards. This means that the adapter is working, documented, plays well with other adapters from the community, and feels part of the preCICE ecosystem. Others can find, build, and run the code, and they are able to understand what is does. The preCICE maintainers are, if necessary, able to maintain the adapter (e.g. update it to newer preCICE versions).
 
-- [ ] R.1: The adapter is accompanied by one or more application cases to test it, covering an extensive part of the claimed functionality.
+- [ ] R.1: The adapter is accompanied by one or more application cases to test it, covering an extensive part of the claimed functionality. These test cases must fulfill the required criteria of the [application case guidelines](community-guidelines-application-cases.html).
 - [ ] R.2: There is a `README.md` file with at least the following information (or links to related resources):
   - [ ] application background and/or nature of coupling (e.g., surface vs. volume coupling; transient or steady-state; ...)
   - [ ] what data can be read and written for a coupling

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -97,7 +97,7 @@ Aim to implement as many of these best practices make sense for you. Each brings
 
 ## An adapter example
 
-The OpenFOAM adapter currently reaches Bronze level conformity, even if it already satisfies many of the higher-level criteria.
+The OpenFOAM adapter conforms to the preCICE best practices and fulfills many of the additional criteria.
 
 Metadata:
 
@@ -108,39 +108,33 @@ Metadata:
 - M.5: https://doi.org/10.51560/ofj.v3.88
 - M.6: library
 
-Bronze:
+Required best practices:
 
-- [x] B.1: https://precice.org/quickstart.html
-- [x] B.2: https://github.com/precice/openfoam-adapter/blob/develop/README.md
-- [x] B.3: https://precice.org/adapter-openfoam-overview.html
-- [x] B.4: https://github.com/precice/openfoam-adapter/blob/develop/LICENSE
-- [x] B.5: https://github.com/precice/openfoam-adapter (public)
-- [x] B.6: https://precice.org/adapter-openfoam-get.html#what-does-the-adapter-version-mean
-- [x] B.7: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
+- [x] R.1: Several application cases are available as tutorials. The application cases list is not yet available.
+- [x] R.2: https://github.com/precice/openfoam-adapter/blob/develop/README.md
+- [x] R.3: https://github.com/precice/openfoam-adapter/blob/develop/LICENSE
+- [x] R.4: https://github.com/precice/openfoam-adapter (public)
+- [x] R.5: https://precice.org/adapter-openfoam-get.html#what-does-the-adapter-version-mean
+- [x] R.6: https://github.com/precice/openfoam-adapter/blob/develop/CHANGELOG.md
+- [x] R.7: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
+- [x] R.8: https://precice.org/adapter-openfoam-config.html
+- [x] R.9: https://precice.org/adapter-openfoam-config.html
 
-Silver:
+Additional criteria:
 
-- [x] S.1: Several application cases are available as tutorials. The application cases list is not yet available.
-- [x] S.2: https://doi.org/10.51560/ofj.v3.88
-- [x] S.3: GPL-3.0
-- [x] S.4: https://github.com/precice/openfoam-adapter
-- [x] S.5: https://precice.org/adapter-openfoam-config.html
-- [x] S.6: https://precice.org/adapter-openfoam-config.html
-- [x] S.7: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
-- [x] S.8: https://github.com/precice/openfoam-adapter/blob/develop/CHANGELOG.md
-- [x] S.9: https://github.com/precice/openfoam-adapter/issues
-- [ ] S.10: While the adapter has been validated, this is not clearly described in the current documentation
-- [x] S.11: on precice.org
-- [x] S.12: public
-- [x] S.13: yes, but only at compile-time
 
-Gold:
-
-- [x] G.1: https://doi.org/10.51560/ofj.v3.88
-- [x] G.2: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
-- [x] G.3: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
-- [ ] G.4: (schema not available yet)
-- [ ] G.5: There are no unit tests
-- [x] G.6: Already integrated into the system tests
-- [x] G.7: https://precice.org/adapter-openfoam-extend.html
-- [x] G.8: https://packages.spack.io/package.html?name=of-precice
+- [x] A.1: GPL-3.0
+- [x] A.2: https://github.com/precice/openfoam-adapter
+- [x] A.3: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
+- [x] A.4: https://github.com/precice/openfoam-adapter/issues
+- [ ] A.5: While the adapter has been validated, this is not clearly described in the current documentation
+- [x] A.6: on precice.org
+- [x] A.7: yes, but only at compile-time
+- [x] A.8: https://doi.org/10.51560/ofj.v3.88
+- [x] A.9: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
+- [x] A.10: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
+- [ ] A.11: (schema not available yet)
+- [ ] A.12: There are no unit tests
+- [x] A.13: Already integrated into the system tests
+- [x] A.14: https://precice.org/adapter-openfoam-extend.html
+- [x] A.15: https://packages.spack.io/package.html?name=of-precice

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -8,13 +8,15 @@ toc: true
 
 v0.2, published on December 4, 2024
 
-Are you developing a preCICE adapter or related tool? Follow these guidelines to make your adapter easier to publish, easier to integrate it with the rest of the preCICE ecosystem, and more useful for the community.
+Are you developing a preCICE adapter or related tool? Follow these guidelines to make your adapter easier to publish, easier to integrate with the rest of the preCICE ecosystem, and more useful for the community.
 
-We distinguish between **metadata** and **best practices**. The best practices are split between required and optional. Adapters fulfilling all the required best practices are listed here as adapters conforming to the preCICE standards. Additional criteria bring further benefits and are visible individually for each adapter. Adapters not fulfilling all the required criteria can still be listed here as legacy adapters.
+We differentiate between adapters and application cases: For example, we consider the ["Nutils adapter"](https://precice.org/adapter-nutils.html) to be a collection of application cases instead of an adapter. An [adapter](https://precice.org/couple-your-code-overview.html) can be a stand-alone software project, but can also be a class, a patch, or something else with significant scholarly effort compared to the uncoupled solver. Other tools that interact with the preCICE API or configuration files can also be considered here, on a case-by-case basis.
 
-We also differentiate here between adapters and application cases: for example, we consider the ["Nutils adapter"](https://precice.org/adapter-nutils.html) to be a collection of application cases instead of an adapter. An [adapter](https://precice.org/couple-your-code-overview.html) can be a stand-alone software project, but can also be a class, a patch, or something else with significant scholarly effort compared to the uncoupled solver. Other tools that interact with the preCICE API or configuration files can also be considered here, on a case-by-case basis.
+For the guidelines, we distinguish between **metadata** and **best practices**. The best practices are split between required and optional. Adapters fulfilling all the required best practices are listed on the preCICE website as adapters conforming to the preCICE standards. Additional criteria bring further benefits and are visible individually for each adapter. Adapters not fulfilling all the required criteria can still be listed here as legacy adapters. By submitting your adapter for review, you can expect a thorough check from the preCICE team on whether these guidelines are met.
 
-By submitting your adapter for review, you can expect a thorough check from the preCICE team on whether these guidelines are met. We cannot do a full code review or a scientific review, and listing your adapter here does not in any way replace a traditional publication, which you can link to.
+{% warning %}
+We are not doing a scientific review and we cannot do a full code review. We are "only" checking best practices, not the scientific correctness of an adapter. Listing your adapter on the preCICE website does not in any way replace a traditional publication, which you can link to.
+{% endwarning %}
 
 {% tip %}
 We are only in the beginning of this standardization journey. Do you have ideas that would make your life easier and integrating your adapter smoother? Comment in [this forum thread](https://precice.discourse.group/t/2125), or click "Edit" to suggest a change in this page.

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -122,7 +122,6 @@ Required best practices:
 
 Additional criteria:
 
-
 - [x] A.1: GPL-3.0
 - [x] A.2: https://github.com/precice/openfoam-adapter
 - [x] A.3: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -21,7 +21,7 @@ We are only in the beginning of this standardization journey. Do you have ideas 
 {% endtip  %}
 
 {% tip %}
-Applying for research funding? Mention in your proposal which level you are planning to achieve during your planned project and how.
+Applying for research funding? Mention in your proposal that you are planning to follow best practices defined by the preCICE community.
 {% endtip  %}
 
 ## Metadata

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -94,43 +94,8 @@ Aim to implement as many of these best practices as make sense for you. Each bri
 - [ ] A.10: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
 - [ ] A.11: The adapter is packaged either on the expected repositories of the respective solver community, or on [Spack](https://spack.io/) ([Spack packages](https://packages.spack.io/)).
 
-## An adapter example
+## Examples
 
-The OpenFOAM adapter conforms to the preCICE best practices and fulfills many of the additional criteria.
+Some examples evaluating these guidelines:
 
-Metadata:
-
-- M.1: OpenFOAM
-- M.2: https://precice.org/adapter-openfoam-overview.html
-- M.3: GPL-3.0
-- M.4: Gerasimos Chourdakis `<gerasimos.chourdakis ipvs.uni-stuttgart.de>`, David Schneider `<david.schneider ipvs.uni-stuttgart.de>`
-- M.5: https://doi.org/10.51560/ofj.v3.88
-- M.6: library
-
-Required best practices:
-
-- [x] R.1: Several application cases are available as tutorials. The application cases list is not yet available.
-- [x] R.2: https://github.com/precice/openfoam-adapter/blob/develop/README.md
-- [x] R.3: https://github.com/precice/openfoam-adapter/blob/develop/LICENSE
-- [x] R.4: https://github.com/precice/openfoam-adapter (public)
-- [x] R.5: https://precice.org/adapter-openfoam-get.html#what-does-the-adapter-version-mean
-- [x] R.6: https://github.com/precice/openfoam-adapter/blob/develop/CHANGELOG.md
-- [x] R.7: https://github.com/precice/openfoam-adapter/issues
-- [x] R.8: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
-- [x] R.9: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
-- [ ] R.10: (schema not available yet)
-- [ ] R.11: See call to `setMeshVertices` in https://github.com/precice/openfoam-adapter/blob/develop/Interface.C
-
-Additional criteria:
-
-- [x] A.1: GPL-3.0
-- [x] A.2: https://github.com/precice/openfoam-adapter
-- [x] A.3: on precice.org
-- [x] A.4: yes, but only at compile-time
-- [x] A.5: https://doi.org/10.51560/ofj.v3.88
-- [x] A.6: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
-- [x] A.7: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
-- [x] A.8: https://precice.org/adapter-openfoam-extend.html
-- [ ] A.9: There are no unit tests
-- [x] A.10: Already integrated into the system tests
-- [x] A.11: https://packages.spack.io/package.html?name=of-precice
+- [OpenFOAM adapter](https://precice.org/community-guidelines-adapters-openfoam.html)

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -69,9 +69,10 @@ We consider an adapter fulfilling all of these criteria as conforming to the pre
 - [ ] R.4: The adapter uses a version control system (public is optional, but strongly encouraged).
 - [ ] R.5: The adapter uses a versioning scheme, such as [semantic versioning](https://semver.org/) (or other clearly defined scheme).
 - [ ] R.6: There is a structured changelog, e.g., using the [keep a changelog](https://keepachangelog.com/) format.
-- [ ] R.7: The adapter has comments and error messages for at least its main building blocks and entry points. These comments are in English.
-- [ ] R.8: The adapter configuration covers the mesh name, data names, participant name, and name of the preCICE configuration file.
-- [ ] R.9: In the adapter configuration, [standard names](community-contribute-to-precice.html#naming-conventions) are possible for the coupled data (e.g., `Displacement`).
+- [ ] R.7: There is an issue tracker.
+- [ ] R.8: There is a code formatting specification (e.g., clang-format specification file).
+- [ ] R.9: The adapter has comments and error messages for at least its main building blocks and entry points. These comments are in English.
+- [ ] R.10: The configuration follows a formally defined schema, which [will be available in the future](https://github.com/precice/preeco-orga/issues/18).
 
 ### Additional
 
@@ -81,21 +82,18 @@ Aim to implement as many of these best practices make sense for you. Each brings
 
 - [ ] A.1: The adapter has an open-source license.
 - [ ] A.2: The adapter uses a publicly-accessible repository.
-- [ ] A.3: There is a code formatting specification (e.g., clang-format specification file).
-- [ ] A.4: There is an issue tracker.
-- [ ] A.5: There is information on how the adapter was validated and how validation could be reproduced.
-- [ ] A.6: The documentation is rendered in a user-friendly way, either:
+- [ ] A.3: There is information on how the adapter was validated and how validation could be reproduced.
+- [ ] A.4: The documentation is rendered in a user-friendly way, either:
   - on precice.org (i.e., in `docs` subfolder, see [preCICE documentation of the documentation](https://precice.org/docs-meta-overview.html))
   - on another website
-- [ ] A.7: The logging is configurable, with levels at least "no logging, release logging, and debug logging".
-- [ ] A.8: There is a peer-reviewed paper (at least in pre-print state) with a validation study, with all data available.
-- [ ] A.9: There are contribution guidelines described in or linked from a `CONTRIBUTING.md` file.
-- [ ] A.10: There is a pull request template.
-- [ ] A.11: The configuration follows a formally defined schema, which [will be available in the future](https://github.com/precice/preeco-orga/issues/18).
-- [ ] A.12: There are unit tests to test components of the adapter, without running another simulation participant (and ideally, using the upcoming [general mocked interface](https://github.com/precice/preeco-orga/issues/4)).
-- [ ] A.13: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
-- [ ] A.14: There is documentation on how to extend the adapter (i.e., documentation about the software architecture).
-- [ ] A.15: The adapter is packaged either on the expected repositories of the respective solver community, or on [Spack](https://spack.io/) ([Spack packages](https://packages.spack.io/)).
+- [ ] A.5: The logging is configurable, with levels at least "no logging, release logging, and debug logging".
+- [ ] A.6: There is a peer-reviewed paper (at least in pre-print state) with a validation study, with all data available.
+- [ ] A.7: There are contribution guidelines described in or linked from a `CONTRIBUTING.md` file.
+- [ ] A.8: There is a pull request template.
+- [ ] A.9: There are unit tests to test components of the adapter, without running another simulation participant (and ideally, using the upcoming [general mocked interface](https://github.com/precice/preeco-orga/issues/4)).
+- [ ] A.10: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
+- [ ] A.11: There is documentation on how to extend the adapter (i.e., documentation about the software architecture).
+- [ ] A.12: The adapter is packaged either on the expected repositories of the respective solver community, or on [Spack](https://spack.io/) ([Spack packages](https://packages.spack.io/)).
 
 ## An adapter example
 
@@ -118,24 +116,22 @@ Required best practices:
 - [x] R.4: https://github.com/precice/openfoam-adapter (public)
 - [x] R.5: https://precice.org/adapter-openfoam-get.html#what-does-the-adapter-version-mean
 - [x] R.6: https://github.com/precice/openfoam-adapter/blob/develop/CHANGELOG.md
-- [x] R.7: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
-- [x] R.8: https://precice.org/adapter-openfoam-config.html
-- [x] R.9: https://precice.org/adapter-openfoam-config.html
+- [x] R.7: https://github.com/precice/openfoam-adapter/issues
+- [x] R.8: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
+- [x] R.9: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
+- [ ] R.10: (schema not available yet)
 
 Additional criteria:
 
 - [x] A.1: GPL-3.0
 - [x] A.2: https://github.com/precice/openfoam-adapter
-- [x] A.3: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
-- [x] A.4: https://github.com/precice/openfoam-adapter/issues
-- [ ] A.5: While the adapter has been validated, this is not clearly described in the current documentation
-- [x] A.6: on precice.org
-- [x] A.7: yes, but only at compile-time
-- [x] A.8: https://doi.org/10.51560/ofj.v3.88
-- [x] A.9: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
-- [x] A.10: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
-- [ ] A.11: (schema not available yet)
-- [ ] A.12: There are no unit tests
-- [x] A.13: Already integrated into the system tests
-- [x] A.14: https://precice.org/adapter-openfoam-extend.html
-- [x] A.15: https://packages.spack.io/package.html?name=of-precice
+- [ ] A.3: While the adapter has been validated, this is not clearly described in the current documentation
+- [x] A.4: on precice.org
+- [x] A.5: yes, but only at compile-time
+- [x] A.6: https://doi.org/10.51560/ofj.v3.88
+- [x] A.7: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
+- [x] A.8: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
+- [ ] A.9: There are no unit tests
+- [x] A.10: Already integrated into the system tests
+- [x] A.11: https://precice.org/adapter-openfoam-extend.html
+- [x] A.12: https://packages.spack.io/package.html?name=of-precice

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -78,7 +78,7 @@ We consider an adapter fulfilling all of these criteria as conforming to the pre
 
 These optional criteria help others to easily reuse and extend the adapter for their own needs. Maintaining the adapter could be shared among many. The preCICE maintainers can integrate the adapter and corresponding application cases into their development workflows. All tooling works seamlessly.
 
-Aim to implement as many of these best practices make sense for you. Each brings additional long-term benefits.
+Aim to implement as many of these best practices as make sense for you. Each brings additional long-term benefits.
 
 - [ ] A.1: The adapter has an open-source license.
 - [ ] A.2: The adapter uses a publicly-accessible repository.

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -82,17 +82,16 @@ Aim to implement as many of these best practices make sense for you. Each brings
 
 - [ ] A.1: The adapter has an open-source license.
 - [ ] A.2: The adapter uses a publicly-accessible repository.
-- [ ] A.3: There is information on how the adapter was validated and how validation could be reproduced.
-- [ ] A.4: The documentation is rendered in a user-friendly way, either:
+- [ ] A.3: The documentation is rendered in a user-friendly way, either:
   - on precice.org (i.e., in `docs` subfolder, see [preCICE documentation of the documentation](https://precice.org/docs-meta-overview.html))
   - on another website
-- [ ] A.5: The logging is configurable, with levels at least "no logging, release logging, and debug logging".
-- [ ] A.6: There is a peer-reviewed paper (at least in pre-print state) with a validation study, with all data available.
-- [ ] A.7: There are contribution guidelines described in or linked from a `CONTRIBUTING.md` file.
-- [ ] A.8: There is a pull request template.
-- [ ] A.9: There are unit tests to test components of the adapter, without running another simulation participant (and ideally, using the upcoming [general mocked interface](https://github.com/precice/preeco-orga/issues/4)).
-- [ ] A.10: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
-- [ ] A.11: There is documentation on how to extend the adapter (i.e., documentation about the software architecture).
+- [ ] A.4: The logging is configurable, with levels at least "no logging, release logging, and debug logging".
+- [ ] A.5: There is a peer-reviewed paper (at least in pre-print state) with a validation study, with all data available.
+- [ ] A.6: There are contribution guidelines described in or linked from a `CONTRIBUTING.md` file.
+- [ ] A.7: There is a pull request template.
+- [ ] A.8: There are unit tests to test components of the adapter, without running another simulation participant (and ideally, using the upcoming [general mocked interface](https://github.com/precice/preeco-orga/issues/4)).
+- [ ] A.9: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
+- [ ] A.10: There is documentation on how to extend the adapter (i.e., documentation about the software architecture).
 - [ ] A.12: The adapter is packaged either on the expected repositories of the respective solver community, or on [Spack](https://spack.io/) ([Spack packages](https://packages.spack.io/)).
 
 ## An adapter example
@@ -126,13 +125,12 @@ Additional criteria:
 
 - [x] A.1: GPL-3.0
 - [x] A.2: https://github.com/precice/openfoam-adapter
-- [ ] A.3: While the adapter has been validated, this is not clearly described in the current documentation
-- [x] A.4: on precice.org
-- [x] A.5: yes, but only at compile-time
-- [x] A.6: https://doi.org/10.51560/ofj.v3.88
-- [x] A.7: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
-- [x] A.8: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
-- [ ] A.9: There are no unit tests
-- [x] A.10: Already integrated into the system tests
-- [x] A.11: https://precice.org/adapter-openfoam-extend.html
-- [x] A.12: https://packages.spack.io/package.html?name=of-precice
+- [x] A.3: on precice.org
+- [x] A.4: yes, but only at compile-time
+- [x] A.5: https://doi.org/10.51560/ofj.v3.88
+- [x] A.6: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
+- [x] A.7: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
+- [ ] A.8: There are no unit tests
+- [x] A.9: Already integrated into the system tests
+- [x] A.10: https://precice.org/adapter-openfoam-extend.html
+- [x] A.11: https://packages.spack.io/package.html?name=of-precice

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -75,7 +75,7 @@ We consider an adapter fulfilling all of these criteria as conforming to the pre
 
 ### Additional
 
-These optional criteria help others easily reuse and extend the adapter for their own needs. Maintaining the adapter could be shared among many. We can integrate the adapter and corresponding application cases into our development workflows and make sure that we will not break it. All tooling works seamlessly.
+These optional criteria help others to easily reuse and extend the adapter for their own needs. Maintaining the adapter could be shared among many. The preCICE maintainers can integrate the adapter and corresponding application cases into their development workflows. All tooling works seamlessly.
 
 Aim to implement as many of these best practices make sense for you. Each brings additional long-term benefits.
 

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -45,7 +45,7 @@ The criteria follow at large the [FAIR criteria for research software](https://d
 
 We consider an adapter fulfilling all of these criteria as conforming to the preCICE standards. This means that the adapter is working, documented, plays well with other adapters from the community, and feels part of the preCICE ecosystem. Others can find, build, and run the code, and they are able to understand what is does. The preCICE maintainers are, if necessary, able to maintain the adapter (e.g. update it to newer preCICE versions).
 
-- [ ] R.1: The adapter is accompanied by one or more application cases to test it, covering an extensive part of the claimed functionality. These cases must be provided as independent application cases.
+- [ ] R.1: The adapter is accompanied by one or more application cases to test it, covering an extensive part of the claimed functionality.
 - [ ] R.2: There is a `README.md` file with at least the following information (or links to related resources):
   - [ ] application background and/or nature of coupling (e.g., surface vs. volume coupling; transient or steady-state; ...)
   - [ ] what data can be read and written for a coupling

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -63,7 +63,6 @@ We consider an adapter fulfilling all of these criteria as conforming to the pre
     - multiple meshes
   - [ ] restrictions on solver features
     - e.g., cannot be run in parallel or cannot use adaptive time stepping or cannot use higher-order elements
-  - [ ] how to cite
   - [ ] references to related studies or literature necessary to understand the modeling and implementation (at least in preprint state).
 - [ ] R.3: The adapter has a clear license (open is optional, but strongly encouraged).
 - [ ] R.4: The adapter uses a version control system (public is optional, but strongly encouraged).

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -73,6 +73,7 @@ We consider an adapter fulfilling all of these criteria as conforming to the pre
 - [ ] R.8: There is a code formatting specification (e.g., clang-format specification file).
 - [ ] R.9: The adapter has comments and error messages for at least its main building blocks and entry points. These comments are in English.
 - [ ] R.10: The configuration follows a formally defined schema, which [will be available in the future](https://github.com/precice/preeco-orga/issues/18).
+- [ ] R.11: Any vertices defined through `setMeshVertex` or `setMeshVertices` need to be real locations in space and the data written to the mesh needs to be data located there, i.e., it is not allowed to decode any other information.
 
 ### Additional
 
@@ -120,6 +121,7 @@ Required best practices:
 - [x] R.8: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
 - [x] R.9: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
 - [ ] R.10: (schema not available yet)
+- [ ] R.11: See call to `setMeshVertices` in https://github.com/precice/openfoam-adapter/blob/develop/Interface.C
 
 Additional criteria:
 

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -6,11 +6,11 @@ summary: Quality guidelines and standards for preCICE adapters and related tools
 toc: true
 ---
 
-v0.1, published on September 23, 2024
+v0.2, published on December 4, 2024
 
 Are you developing a preCICE adapter or related tool? Follow these guidelines to make your adapter easier to publish, easier to integrate it with the rest of the preCICE ecosystem, and more useful for the community.
 
-We distinguish between **metadata** and **best practices**, with three levels: bronze, silver, and gold. We plan to publish a list of all adapters that have achieved at least bronze level, together with the respective metadata. Higher levels bring higher visibility and further benefits.
+We distinguish between **metadata** and **best practices**. The best practices are split between required and optional. Adapters fulfilling all the required best practices are listed here as adapters conforming to the preCICE standards. Additional criteria bring further benefits and are visible individually for each adapter. Adapters not fulfilling all the required criteria can still be listed here as legacy adapters.
 
 We also differentiate here between adapters and application cases: for example, we consider the ["Nutils adapter"](https://precice.org/adapter-nutils.html) to be a collection of application cases instead of an adapter. An [adapter](https://precice.org/couple-your-code-overview.html) can be a stand-alone software project, but can also be a class, a patch, or something else with significant scholarly effort compared to the uncoupled solver. Other tools that interact with the preCICE API or configuration files can also be considered here, on a case-by-case basis.
 
@@ -35,14 +35,16 @@ Applying for research funding? Mention in your proposal which level you are plan
 
 ## Best practices
 
-We distinguish between three levels: bronze, silver, and gold.
+We distinguish between required and additional, optional best practices.
 
-### Bronze
+The criteria follow at large the [FAIR criteria for research software](https://doi.org/10.1038/s41597-022-01710-x): Findable (documented), Accessible (working), Interoperable (standardized), and Reusable (integratable).
 
-We consider an adapter fulfilling all of these criteria as *Findable* and *Accessible*. This means that the adapter is working and documented. Others can find, build, and run the code, and they are able to understand what is does.
+### Required
 
-- [ ] B.1: The adapter is accompanied by at least one application case to test it, covering at least a defined minimum functionality. The test case can be provided as an independent application case or included in the adapter.
-- [ ] B.2: There is a `README.md` file with at least the following information (or links to related resources):
+We consider an adapter fulfilling all of these criteria as conforming to the preCICE standards. This means that the adapter is working, documented, plays well with other adapters from the community, and feels part of the preCICE ecosystem. Others can find, build, and run the code, and they are able to understand what is does. The preCICE maintainers are, if necessary, able to maintain the adapter (e.g. update it to newer preCICE versions).
+
+- [ ] R.1: The adapter is accompanied by one or more application cases to test it, covering an extensive part of the claimed functionality. These cases must be provided as independent application cases.
+- [ ] R.2: There is a `README.md` file with at least the following information (or links to related resources):
   - [ ] application background and/or nature of coupling (e.g., surface vs. volume coupling; transient or steady-state; ...)
   - [ ] what data can be read and written for a coupling
   - [ ] which target solver versions are supported
@@ -60,42 +62,38 @@ We consider an adapter fulfilling all of these criteria as *Findable* and *Acces
   - [ ] restrictions on solver features
     - e.g., cannot be run in parallel or cannot use adaptive time stepping or cannot use higher-order elements
   - [ ] how to cite
-- [ ] B.3: The adapter has a clear license (open is optional, but strongly encouraged).
-- [ ] B.4: The adapter uses a version control system (public is optional, but strongly encouraged).
-- [ ] B.5: The adapter uses a versioning scheme, such as [semantic versioning](https://semver.org/) (or other clearly defined scheme).
-- [ ] B.6: The adapter has comments and error messages for at least its main building blocks and entry points. These comments are in English.
+  - [ ] references to related studies or literature necessary to understand the modeling and implementation (at least in preprint state).
+- [ ] R.3: The adapter has a clear license (open is optional, but strongly encouraged).
+- [ ] R.4: The adapter uses a version control system (public is optional, but strongly encouraged).
+- [ ] R.5: The adapter uses a versioning scheme, such as [semantic versioning](https://semver.org/) (or other clearly defined scheme).
+- [ ] R.6: There is a structured changelog, e.g., using the [keep a changelog](https://keepachangelog.com/) format.
+- [ ] R.7: The adapter has comments and error messages for at least its main building blocks and entry points. These comments are in English.
+- [ ] R.8: The adapter configuration covers the mesh name, data names, participant name, and name of the preCICE configuration file.
+- [ ] R.9: In the adapter configuration, [standard names](community-contribute-to-precice.html#naming-conventions) are possible for the coupled data (e.g., `Displacement`).
 
-### Silver
+### Additional
 
-We consider an adapter fulfilling all of these criteria as *Interoperable* and *maintainable*. The adapter plays well with other adapters from the community and feels part of the preCICE ecosystem. The preCICE maintainers are, if necessary, able to maintain the adapter (e.g. update it to newer preCICE versions).
+These optional criteria help others easily reuse and extend the adapter for their own needs. Maintaining the adapter could be shared among many. We can integrate the adapter and corresponding application cases into our development workflows and make sure that we will not break it. All tooling works seamlessly.
 
-- [ ] S.1: The adapter is accompanied by one or more application cases to test it, covering an extensive part of the claimed functionality. These cases must be provided as independent application cases.
-- [ ] S.2: The documentation provides references to related studies or literature necessary to understand the modeling and implementation (at least in preprint state).
-- [ ] S.3: The adapter has an open-source license.
-- [ ] S.4: The adapter uses a publicly-accessible repository.
-- [ ] S.5: The adapter configuration covers the mesh name, data names, participant name, and name of the preCICE configuration file.
-- [ ] S.6: In the adapter configuration, [standard names](community-contribute-to-precice.html#naming-conventions) are possible for the coupled data (e.g., `Displacement`).
-- [ ] S.7: There is a code formatting specification (e.g., clang-format specification file).
-- [ ] S.8: There is a structured changelog, e.g., using the [keep a changelog](https://keepachangelog.com/) format.
-- [ ] S.9: There is an issue tracker.
-- [ ] S.10: There is information on how the adapter was validated and how validation could be reproduced.
-- [ ] S.11: The documentation is rendered in a user-friendly way, either:
+Aim to implement as many of these best practices make sense for you. Each brings additional long-term benefits.
+
+- [ ] A.1: The adapter has an open-source license.
+- [ ] A.2: The adapter uses a publicly-accessible repository.
+- [ ] A.3: There is a code formatting specification (e.g., clang-format specification file).
+- [ ] A.4: There is an issue tracker.
+- [ ] A.5: There is information on how the adapter was validated and how validation could be reproduced.
+- [ ] A.6: The documentation is rendered in a user-friendly way, either:
   - on precice.org (i.e., in `docs` subfolder, see [preCICE documentation of the documentation](https://precice.org/docs-meta-overview.html))
   - on another website
-- [ ] S.12: The logging is configurable, with levels at least "no logging, release logging, and debug logging".
-
-### Gold
-
-We consider an adapter fulfilling all of these criteria as *Reusable*, *community-ready*, and *integrated*. Others can easily reuse and extend the adapter for their own needs. Maintaining the adapter could be shared among many. We can integrate the adapter and corresponding application cases into our development workflows and make sure that we will not break it. All tooling works seamlessly.
-
-- [ ] G.1: There is a peer-reviewed paper (at least in pre-print state) with a validation study, with all data available.
-- [ ] G.2: There are contribution guidelines described in or linked from a `CONTRIBUTING.md` file.
-- [ ] G.3: There is a pull request template.
-- [ ] G.4: The configuration follows a formally defined schema, which [will be available in the future](https://github.com/precice/preeco-orga/issues/18).
-- [ ] G.5: There are unit tests to test components of the adapter, without running another simulation participant (and ideally, using the upcoming [general mocked interface](https://github.com/precice/preeco-orga/issues/4)).
-- [ ] G.6: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
-- [ ] G.7: There is documentation on how to extend the adapter (i.e., documentation about the software architecture).
-- [ ] G.8: The adapter is packaged either on the expected repositories of the respective solver community, or on [Spack](https://spack.io/) ([Spack packages](https://packages.spack.io/)).
+- [ ] A.7: The logging is configurable, with levels at least "no logging, release logging, and debug logging".
+- [ ] A.8: There is a peer-reviewed paper (at least in pre-print state) with a validation study, with all data available.
+- [ ] A.9: There are contribution guidelines described in or linked from a `CONTRIBUTING.md` file.
+- [ ] A.10: There is a pull request template.
+- [ ] A.11: The configuration follows a formally defined schema, which [will be available in the future](https://github.com/precice/preeco-orga/issues/18).
+- [ ] A.12: There are unit tests to test components of the adapter, without running another simulation participant (and ideally, using the upcoming [general mocked interface](https://github.com/precice/preeco-orga/issues/4)).
+- [ ] A.13: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
+- [ ] A.14: There is documentation on how to extend the adapter (i.e., documentation about the software architecture).
+- [ ] A.15: The adapter is packaged either on the expected repositories of the respective solver community, or on [Spack](https://spack.io/) ([Spack packages](https://packages.spack.io/)).
 
 ## An adapter example
 

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -89,10 +89,10 @@ Aim to implement as many of these best practices make sense for you. Each brings
 - [ ] A.5: There is a peer-reviewed paper (at least in pre-print state) with a validation study, with all data available.
 - [ ] A.6: There are contribution guidelines described in or linked from a `CONTRIBUTING.md` file.
 - [ ] A.7: There is a pull request template.
-- [ ] A.8: There are unit tests to test components of the adapter, without running another simulation participant (and ideally, using the upcoming [general mocked interface](https://github.com/precice/preeco-orga/issues/4)).
-- [ ] A.9: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
-- [ ] A.10: There is documentation on how to extend the adapter (i.e., documentation about the software architecture).
-- [ ] A.12: The adapter is packaged either on the expected repositories of the respective solver community, or on [Spack](https://spack.io/) ([Spack packages](https://packages.spack.io/)).
+- [ ] A.8: There is documentation on how to extend the adapter (i.e., documentation about the software architecture).
+- [ ] A.9: There are unit tests to test components of the adapter, without running another simulation participant (and ideally, using the upcoming [general mocked interface](https://github.com/precice/preeco-orga/issues/4)).
+- [ ] A.10: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
+- [ ] A.11: The adapter is packaged either on the expected repositories of the respective solver community, or on [Spack](https://spack.io/) ([Spack packages](https://packages.spack.io/)).
 
 ## An adapter example
 
@@ -130,7 +130,7 @@ Additional criteria:
 - [x] A.5: https://doi.org/10.51560/ofj.v3.88
 - [x] A.6: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
 - [x] A.7: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
-- [ ] A.8: There are no unit tests
-- [x] A.9: Already integrated into the system tests
-- [x] A.10: https://precice.org/adapter-openfoam-extend.html
+- [x] A.8: https://precice.org/adapter-openfoam-extend.html
+- [ ] A.9: There are no unit tests
+- [x] A.10: Already integrated into the system tests
 - [x] A.11: https://packages.spack.io/package.html?name=of-precice

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -6,7 +6,7 @@ summary: Quality guidelines and standards for preCICE adapters and related tools
 toc: true
 ---
 
-v0.2, published on December 4, 2024
+v0.2, published on December 9, 2024
 
 Are you developing a preCICE adapter or related tool? Follow these guidelines to make your adapter easier to publish, easier to integrate with the rest of the preCICE ecosystem, and more useful for the community.
 


### PR DESCRIPTION
Still needs a corresponding PR in the website.