### PR TITLE
Move the OpenFOAM adapter guidelines example to a separate page

### DIFF
--- a/guidelines/guidelines-adapters-openfoam.md
+++ b/guidelines/guidelines-adapters-openfoam.md
@@ -1,0 +1,46 @@
+---
+title: Standardization example - OpenFOAM adapter
+permalink: community-guidelines-adapters-openfoam.html
+keywords: contribute, develop, adapters, standardization, preECO, OpenFOAM
+summary: A review of the OpenFOAM adapter using the contributing guidelines. This is a work-in-progress that will eventually be moved.
+toc: true
+---
+
+The OpenFOAM adapter conforms to the preCICE best practices and fulfills many of the additional criteria.
+
+Metadata:
+
+- M.1: OpenFOAM
+- M.2: https://precice.org/adapter-openfoam-overview.html
+- M.3: GPL-3.0
+- M.4: Gerasimos Chourdakis `<gerasimos.chourdakis ipvs.uni-stuttgart.de>`, David Schneider `<david.schneider ipvs.uni-stuttgart.de>`
+- M.5: https://doi.org/10.51560/ofj.v3.88
+- M.6: library
+
+Required best practices:
+
+- [x] R.1: Several application cases are available as tutorials. The application cases list is not yet available.
+- [x] R.2: https://github.com/precice/openfoam-adapter/blob/develop/README.md
+- [x] R.3: https://github.com/precice/openfoam-adapter/blob/develop/LICENSE
+- [x] R.4: https://github.com/precice/openfoam-adapter (public)
+- [x] R.5: https://precice.org/adapter-openfoam-get.html#what-does-the-adapter-version-mean
+- [x] R.6: https://github.com/precice/openfoam-adapter/blob/develop/CHANGELOG.md
+- [x] R.7: https://github.com/precice/openfoam-adapter/issues
+- [x] R.8: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
+- [x] R.9: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
+- [ ] R.10: Still requires porting of single fields, e.g. `preciceConfig` → `preciceConfigFileName`.
+- [x] R.11: See call to `setMeshVertices` in https://github.com/precice/openfoam-adapter/blob/develop/Interface.C
+
+Additional criteria:
+
+- [x] A.1: GPL-3.0
+- [x] A.2: https://github.com/precice/openfoam-adapter
+- [x] A.3: on precice.org
+- [x] A.4: yes, but only at compile-time
+- [x] A.5: https://doi.org/10.51560/ofj.v3.88
+- [x] A.6: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
+- [x] A.7: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
+- [x] A.8: https://precice.org/adapter-openfoam-extend.html
+- [ ] A.9: There are no unit tests
+- [x] A.10: Already integrated into the system tests
+- [x] A.11: https://packages.spack.io/package.html?name=of-precice

--- a/guidelines/guidelines-adapters-openfoam.md
+++ b/guidelines/guidelines-adapters-openfoam.md
@@ -6,7 +6,7 @@ summary: A review of the OpenFOAM adapter using the contributing guidelines. Thi
 toc: true
 ---
 
-The OpenFOAM adapter conforms to the preCICE best practices and fulfills many of the additional criteria.
+The OpenFOAM adapter conforms to most of the preCICE best practices and fulfills many of the additional criteria.
 
 Metadata:
 

--- a/guidelines/guidelines-adapters-openfoam.md
+++ b/guidelines/guidelines-adapters-openfoam.md
@@ -20,13 +20,13 @@ Metadata:
 Required best practices:
 
 - [x] R.1: Several application cases are available as tutorials. The application cases list is not yet available.
-- [x] R.2: https://github.com/precice/openfoam-adapter/blob/develop/README.md
-- [x] R.3: https://github.com/precice/openfoam-adapter/blob/develop/LICENSE
-- [x] R.4: https://github.com/precice/openfoam-adapter (public)
-- [x] R.5: https://precice.org/adapter-openfoam-get.html#what-does-the-adapter-version-mean
-- [x] R.6: https://github.com/precice/openfoam-adapter/blob/develop/CHANGELOG.md
-- [x] R.7: https://github.com/precice/openfoam-adapter/issues
-- [x] R.8: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
+- [x] R.2: [`README.md`](https://github.com/precice/openfoam-adapter/blob/develop/README.md)
+- [x] R.3: [`LICENSE`](https://github.com/precice/openfoam-adapter/blob/develop/LICENSE)
+- [x] R.4: [GitHub project](https://github.com/precice/openfoam-adapter) (public)
+- [x] R.5: [versioning scheme](https://precice.org/adapter-openfoam-get.html#what-does-the-adapter-version-mean)
+- [x] R.6: [`CHANGELOG.md`](https://github.com/precice/openfoam-adapter/blob/develop/CHANGELOG.md)
+- [x] R.7: [issue tracker on GitHub](https://github.com/precice/openfoam-adapter/issues)
+- [x] R.8: [`.clang-format`](https://github.com/precice/openfoam-adapter/blob/develop/.clang-format)
 - [x] R.9: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
 - [ ] R.10: Still requires porting of single fields, e.g. `preciceConfig` → `preciceConfigFileName`.
 - [x] R.11: See call to `setMeshVertices` in https://github.com/precice/openfoam-adapter/blob/develop/Interface.C
@@ -34,13 +34,13 @@ Required best practices:
 Additional criteria:
 
 - [x] A.1: GPL-3.0
-- [x] A.2: https://github.com/precice/openfoam-adapter
+- [x] A.2: [repository](https://github.com/precice/openfoam-adapter) is publicly accessible
 - [x] A.3: on precice.org
 - [x] A.4: yes, but only at compile-time
-- [x] A.5: https://doi.org/10.51560/ofj.v3.88
-- [x] A.6: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
-- [x] A.7: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
-- [x] A.8: https://precice.org/adapter-openfoam-extend.html
+- [x] A.5: [reference paper](https://doi.org/10.51560/ofj.v3.88)
+- [x] A.6: [`CONTRIBUTING.md`](https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md)
+- [x] A.7: [`pull_request_template.md`](https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md)
+- [x] A.8: [documentation on extending the adapter](https://precice.org/adapter-openfoam-extend.html)
 - [ ] A.9: There are no unit tests
 - [x] A.10: Already integrated into the system tests
-- [x] A.11: https://packages.spack.io/package.html?name=of-precice
+- [x] A.11: [Spack package `of-precice`](https://packages.spack.io/package.html?name=of-precice)

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -96,41 +96,8 @@ Aim to implement as many of these best practices as make sense for you. Each bri
 
 ## An adapter example
 
-The OpenFOAM adapter conforms to the preCICE best practices and fulfills many of the additional criteria.
+Some examples evaluating these guidelines:
 
-Metadata:
+- [OpenFOAM adapter](https://precice.org/community-guidelines-adapters-openfoam.html)
 
-- M.1: OpenFOAM
-- M.2: https://precice.org/adapter-openfoam-overview.html
-- M.3: GPL-3.0
-- M.4: Gerasimos Chourdakis `<gerasimos.chourdakis ipvs.uni-stuttgart.de>`, David Schneider `<david.schneider ipvs.uni-stuttgart.de>`
-- M.5: https://doi.org/10.51560/ofj.v3.88
-- M.6: library
-
-Required best practices:
-
-- [x] R.1: Several application cases are available as tutorials. The application cases list is not yet available.
-- [x] R.2: https://github.com/precice/openfoam-adapter/blob/develop/README.md
-- [x] R.3: https://github.com/precice/openfoam-adapter/blob/develop/LICENSE
-- [x] R.4: https://github.com/precice/openfoam-adapter (public)
-- [x] R.5: https://precice.org/adapter-openfoam-get.html#what-does-the-adapter-version-mean
-- [x] R.6: https://github.com/precice/openfoam-adapter/blob/develop/CHANGELOG.md
-- [x] R.7: https://github.com/precice/openfoam-adapter/issues
-- [x] R.8: https://github.com/precice/openfoam-adapter/blob/develop/.clang-format
-- [x] R.9: See, for example, https://github.com/precice/openfoam-adapter/blob/develop/Adapter.H
-- [ ] R.10: Still requires porting of single fields, e.g. `preciceConfig` → `preciceConfigFileName`.
-- [ ] R.11: See call to `setMeshVertices` in https://github.com/precice/openfoam-adapter/blob/develop/Interface.C
-
-Additional criteria:
-
-- [x] A.1: GPL-3.0
-- [x] A.2: https://github.com/precice/openfoam-adapter
-- [x] A.3: on precice.org
-- [x] A.4: yes, but only at compile-time
-- [x] A.5: https://doi.org/10.51560/ofj.v3.88
-- [x] A.6: https://github.com/precice/openfoam-adapter/blob/develop/CONTRIBUTING.md
-- [x] A.7: https://github.com/precice/openfoam-adapter/blob/develop/.github/pull_request_template.md
-- [x] A.8: https://precice.org/adapter-openfoam-extend.html
-- [ ] A.9: There are no unit tests
-- [x] A.10: Already integrated into the system tests
-- [x] A.11: https://packages.spack.io/package.html?name=of-precice
+Note that these pages will be removed once the guidelines are converged and a better system is in place to render this information.

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -94,7 +94,7 @@ Aim to implement as many of these best practices as make sense for you. Each bri
 - [ ] A.10: The repository is ready to be integrated into the [preCICE system tests](https://precice.org/dev-docs-system-tests.html): A simulation can start using an unsupervised script and there is enough information to create entries under `component-templates/` and `components.yaml`.
 - [ ] A.11: The adapter is packaged either on the expected repositories of the respective solver community, or on [Spack](https://spack.io/) ([Spack packages](https://packages.spack.io/)).
 
-## An adapter example
+## Examples
 
 Some examples evaluating these guidelines:
 


### PR DESCRIPTION
Respective PR in the website: https://github.com/precice/precice.github.io/pull/495