### PR TITLE
Model solver name and operation as data properties

### DIFF
--- a/adapter-config-schema/precice_adapter_config_schema.json
+++ b/adapter-config-schema/precice_adapter_config_schema.json
@@ -72,97 +72,14 @@
             "type": "array",
             "description": "List of data fields to be written to this mesh.",
             "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Name of the data as specified in the preCICE configuration.",
-                  "default": "Force",
-                  "examples": [
-                    "Force",
-                    "Displacement",
-                    "Velocity",
-                    "Temperature",
-                    "Heat-Flux",
-                    "Force1",
-                    "Force-Left",
-                    "Heat-Transfer-Coefficient",
-                    "Sink-Temperature"
-                  ],
-                  "minLength": 1,
-                  "pattern": "^[A-Z][a-zA-Z0-9]*(?:-[A-Za-z0-9]+)*$"
-                },
-                "solver_name": {
-                  "type": "string",
-                  "description": "Name of the data as used by the solver (optional).",
-                  "examples": [
-                    "temp",
-                    "T"
-                  ],
-                  "minLength": 1
-                },
-                "operation": {
-                  "type": "string",
-                  "description": "Operation applied by the adapter on the data (optional).",
-                  "examples": [
-                    "value",
-                    "gradient"
-                  ],
-                  "minLength": 1
-                }
-              },
-              "required": [
-                "name"
-              ]
+              "$ref": "#/$defs/precice_data"
             },
             "minItems": 1
           },
           "read_data": {
             "type": "array",
             "description": "List of data fields to be read from this mesh.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Name of the data as specified in the preCICE configuration.",
-                  "default": "Force",
-                  "examples": [
-                    "Force",
-                    "Displacement",
-                    "Velocity",
-                    "Temperature",
-                    "Heat-Flux",
-                    "Force1",
-                    "Force-Left",
-                    "Heat-Transfer-Coefficient",
-                    "Sink-Temperature"
-                  ],
-                  "minLength": 1,
-                  "pattern": "^[A-Z][a-zA-Z0-9]*(?:-[A-Za-z0-9]+)*$"
-                },
-                "solver_name": {
-                  "type": "string",
-                  "description": "Name of the data as used by the solver (optional)",
-                  "examples": [
-                    "temp",
-                    "T"
-                  ],
-                  "minLength": 1
-                },
-                "operation": {
-                  "type": "string",
-                  "description": "Operation applied by the adapter on the data (optional)",
-                  "examples": [
-                    "value",
-                    "gradient"
-                  ],
-                  "minLength": 1
-                }
-              },
-              "required": [
-                "name"
-              ]
+              "$ref": "#/$defs/precice_data"
             },
             "minItems": 1
           },
@@ -196,5 +113,51 @@
     "participant_name",
     "precice_config_file_name",
     "interfaces"
-  ]
+  ],
+  "$defs": {
+    "precice_data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the data as specified in the preCICE configuration.",
+          "default": "Force",
+          "examples": [
+            "Force",
+            "Displacement",
+            "Velocity",
+            "Temperature",
+            "Heat-Flux",
+            "Force1",
+            "Force-Left",
+            "Heat-Transfer-Coefficient",
+            "Sink-Temperature"
+          ],
+          "minLength": 1,
+          "pattern": "^[A-Z][a-zA-Z0-9]*(?:-[A-Za-z0-9]+)*$"
+        },
+        "solver_name": {
+          "type": "string",
+          "description": "Name of the data as used by the solver (optional).",
+          "examples": [
+            "temp",
+            "T"
+          ],
+          "minLength": 1
+        },
+        "operation": {
+          "type": "string",
+          "description": "Operation applied by the adapter on the data (optional).",
+          "examples": [
+            "value",
+            "gradient"
+          ],
+          "minLength": 1
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  }
 }

--- a/adapter-config-schema/precice_adapter_config_schema.json
+++ b/adapter-config-schema/precice_adapter_config_schema.json
@@ -68,45 +68,101 @@
               "nodes"
             ]
           },
-          "write_data_names": {
+          "write_data": {
             "type": "array",
-            "description": "List of data fields to be written on this mesh.",
+            "description": "List of data fields to be written to this mesh.",
             "items": {
-              "type": "string",
-              "default": "Force",
-              "examples": [
-                "Force",
-                "Displacement",
-                "Velocity",
-                "Temperature",
-                "Heat-Flux",
-                "Force1",
-                "Force-Left",
-                "Heat-Transfer-Coefficient",
-                "Sink-Temperature"
-              ],
-              "minLength": 1,
-              "pattern": "^[A-Z][a-zA-Z0-9]*(?:-[A-Za-z0-9]+)*$"
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the data as specified in the preCICE configuration.",
+                  "default": "Force",
+                  "examples": [
+                    "Force",
+                    "Displacement",
+                    "Velocity",
+                    "Temperature",
+                    "Heat-Flux",
+                    "Force1",
+                    "Force-Left",
+                    "Heat-Transfer-Coefficient",
+                    "Sink-Temperature"
+                  ],
+                  "minLength": 1,
+                  "pattern": "^[A-Z][a-zA-Z0-9]*(?:-[A-Za-z0-9]+)*$"
+                },
+                "solver_name": {
+                  "type": "string",
+                  "description": "Name of the data as used by the solver (optional).",
+                  "examples": [
+                    "temp",
+                    "T"
+                  ],
+                  "minLength": 1
+                },
+                "operation": {
+                  "type": "string",
+                  "description": "Operation applied by the adapter on the data (optional).",
+                  "examples": [
+                    "value",
+                    "gradient"
+                  ],
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "name"
+              ]
             },
             "minItems": 1
           },
-          "read_data_names": {
+          "read_data": {
             "type": "array",
-            "description": "List of data fields to be read on this mesh.",
+            "description": "List of data fields to be read from this mesh.",
             "items": {
-              "type": "string",
-              "default": "Force",
-              "examples": [
-                "Force",
-                "Displacement",
-                "Velocity",
-                "Temperature",
-                "Heat-Flux",
-                "Force1",
-                "Force-Left"
-              ],
-              "minLength": 1,
-              "pattern": "^[A-Z][a-zA-Z0-9]*(?:-[A-Za-z0-9]+)*$"
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the data as specified in the preCICE configuration.",
+                  "default": "Force",
+                  "examples": [
+                    "Force",
+                    "Displacement",
+                    "Velocity",
+                    "Temperature",
+                    "Heat-Flux",
+                    "Force1",
+                    "Force-Left",
+                    "Heat-Transfer-Coefficient",
+                    "Sink-Temperature"
+                  ],
+                  "minLength": 1,
+                  "pattern": "^[A-Z][a-zA-Z0-9]*(?:-[A-Za-z0-9]+)*$"
+                },
+                "solver_name": {
+                  "type": "string",
+                  "description": "Name of the data as used by the solver (optional)",
+                  "examples": [
+                    "temp",
+                    "T"
+                  ],
+                  "minLength": 1
+                },
+                "operation": {
+                  "type": "string",
+                  "description": "Operation applied by the adapter on the data (optional)",
+                  "examples": [
+                    "value",
+                    "gradient"
+                  ],
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "name"
+              ]
             },
             "minItems": 1
           },

--- a/adapter-config-schema/precice_adapter_config_schema.json
+++ b/adapter-config-schema/precice_adapter_config_schema.json
@@ -79,6 +79,7 @@
           "read_data": {
             "type": "array",
             "description": "List of data fields to be read from this mesh.",
+            "items": {
               "$ref": "#/$defs/precice_data"
             },
             "minItems": 1


### PR DESCRIPTION
Closes #36

## Current suggestions

- `name`, not `precice_data_name` as property name: "data" is covered in the object name and "precice" should be clear enough (it is also `mesh_name`, not `precice_mesh_name`)
- `solver_name`, not `adapter_name` as property name: It is a name given by the solver, not the adapter if I understood the situation the right way

Also have a look at the descriptions in the schema. These will be our documentation.


## Some examples

In JSON with all options:

```json
{
  "participant_name": "Fluid",
  "precice_config_file_name": "../precice-config.xml",
  "interfaces": [
    {
      "mesh_name": "Fluid-Mesh",
      "write_data": [
        {
          "name": "Force",
          "solver_name": "f0",
          "operation": "blob"
        },
        {
          "name": "Heat-Flux",
          "solver_name": "T",
          "operation": "gradient"
        }
      ],
      "location": "volumeCenters",
      "is_received": false
    }
  ]
}
```

In YAML with only required options:

```yml
participant_name: Fluid
precice_config_file_name: ../precice-config.xml
interfaces:
  - mesh_name: Fluid-Mesh
    write_data:
      - name: Force
```

To further test the schema, I can always recommend testing with the [Meta Configurator](https://metaconfigurator.github.io/meta-configurator/).

## Review

- @tapegoji @BenjaminRodenberg @mathiskelm @IshaanDesai @vidulejs @MakisH @dabele: Does this cover your requirements?
- Any more example names we could add?
- @Logende We could probably remove some duplication between read data and write data in the schema now, right? (Feel free to directly push to this branch)