### PR TITLE
Add more default values to adapter config schema

### DIFF
--- a/adapter-config-schema/precice_adapter_config_schema.json
+++ b/adapter-config-schema/precice_adapter_config_schema.json
@@ -13,6 +13,7 @@
     "participant_name": {
       "type": "string",
       "description": "Name of the participant.",
+      "default": "Fluid",
       "examples": [
         "Fluid",
         "Solid",
@@ -36,6 +37,7 @@
           "mesh_name": {
             "type": "string",
             "description": "Name of the mesh associated with this interface.",
+            "default": "Fluid-Mesh",
             "examples": [
               "Fluid-Mesh",
               "Solid-Mesh",
@@ -71,6 +73,7 @@
             "description": "List of data fields to be written on this mesh.",
             "items": {
               "type": "string",
+              "default": "Force",
               "examples": [
                 "Force",
                 "Displacement",
@@ -92,6 +95,7 @@
             "description": "List of data fields to be read on this mesh.",
             "items": {
               "type": "string",
+              "default": "Force",
               "examples": [
                 "Force",
                 "Displacement",


### PR DESCRIPTION
MetaConfigurator will automatically add the default values of required properties to the document.

Adding more defaults to the schema will make the user experience more easy, because the user will have more fields automatically added to their document.