### PR TITLE
Adapter guidelines: add M.7 for supported preCICE version

### DIFF
--- a/guidelines/guideline-adapters-dumux.md
+++ b/guidelines/guideline-adapters-dumux.md
@@ -16,6 +16,7 @@ Metadata:
 - M.4: Ishaan Desai `<ishaan.desai ipvs.uni-stuttgart.de>`, Jun Chen `<jun.chen ipvs.uni-stuttgart.de>`
 - M.5: (There is no code-specific publication related to the DuMux adapter available yet.)
 - M.6: Library
+- M.7: preCICE v3
 
 Required best practices:
 

--- a/guidelines/guidelines-adapters-issm.md
+++ b/guidelines/guidelines-adapters-issm.md
@@ -16,6 +16,7 @@ Metadata:
 - M.4: Daniel Abele `<daniel.abele dlr.de>`, Angelika Humbert `<angelika.humbert awi.de>`
 - M.5: https://doi.org/10.5194/egusphere-2025-3345
 - M.6: stand-alone
+- M.7: preCICE v3
 
 Required best practices:
 

--- a/guidelines/guidelines-adapters-opendihu.md
+++ b/guidelines/guidelines-adapters-opendihu.md
@@ -16,6 +16,7 @@ Metadata:
 - M.4: Carme Homs-Pons `<carme.homs-pons ipvs.uni-stuttgart.de>`
 - M.5: Reference academic publication by [Maier et al](https://www.sciencedirect.com/science/article/pii/S187775032400084X?via%3Dihub).
 - M.6: Integrated
+- M.7: preCICE v3
 
 Required best practices:
 

--- a/guidelines/guidelines-adapters-openfoam.md
+++ b/guidelines/guidelines-adapters-openfoam.md
@@ -16,6 +16,7 @@ Metadata:
 - M.4: Gerasimos Chourdakis `<gerasimos.chourdakis ipvs.uni-stuttgart.de>`, David Schneider `<david.schneider ipvs.uni-stuttgart.de>`
 - M.5: https://doi.org/10.51560/ofj.v3.88
 - M.6: library
+- M.7: preCICE v3
 
 Required best practices:
 

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -35,6 +35,7 @@ Applying for research funding? Mention in your proposal that you are planning to
 - M.5: How to cite, for attribution purposes (DOI or full information)
    - In case no software publication or other academic publication is available, use repository URL and comment on the lack thereof.
 - M.6: Type of adapter (curated list: stand-alone, library, patch, integrated, ...)
+- M.7: Supported preCICE version
 
 ## Best practices
 


### PR DESCRIPTION
As discussed in https://github.com/precice/preeco-orga/issues/7#issuecomment-3708503267

Note that in the [application case guidelines](https://precice.org/community-guidelines-application-cases.html), we have:

- M.6: Used preCICE version (release/branch/commit), including build config if different from default
- M.10: Used preCICE features. Curated list includes:  ...

Probably we also need to bump the version number (now or later).