### PR TITLE
Bump version to v0.4

### DIFF
--- a/adapter-config-schema/precice_adapter_config_schema.json
+++ b/adapter-config-schema/precice_adapter_config_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/precice/preeco-orga/releases/download/v0.3/precice_adapter_config_schema.json",
+  "$id": "https://github.com/precice/preeco-orga/releases/download/v0.4/precice_adapter_config_schema.json",
   "type": "object",
   "metaConfigurator": {
     "aiExportFormats": {

--- a/guidelines/guidelines-adapters.md
+++ b/guidelines/guidelines-adapters.md
@@ -6,7 +6,7 @@ summary: Quality guidelines and standards for preCICE adapters and related tools
 toc: true
 ---
 
-v0.3, published on September 5, 2025
+v0.4, published on January 26, 2026
 
 Are you developing a preCICE adapter or related tool? Follow these guidelines to make your adapter easier to publish, easier to integrate with the rest of the preCICE ecosystem, and more useful for the community.
 

--- a/guidelines/guidelines-application-cases.md
+++ b/guidelines/guidelines-application-cases.md
@@ -6,7 +6,7 @@ summary: Quality guidelines and standards for application cases
 toc: true
 ---
 
-v0.3, published on September 5, 2025
+v0.4, published on January 26, 2026
 
 Are you preparing one or several application cases for a data publication to accompany your journal article? Follow these guidelines to make your cases easier to integrate with the rest of the preCICE ecosystem and, thus, easier to reproduce, to maintain, and to build upon.
 


### PR DESCRIPTION
Bumps the version from v0.3 to v0.4.

Changes included in the adapter guidelines: #63 (new metadata field M.7)

No changes in the application case guidelines or in the schema, but bumping their versions for consistency, and to be able to access them via the same release.